### PR TITLE
Change color of link from white to red

### DIFF
--- a/src/Components/Styles/Styles.js
+++ b/src/Components/Styles/Styles.js
@@ -15,13 +15,20 @@ const Styles = () => {
         ></img>
         <figcaption>
           Photo by{' '}
-          <a href="https://unsplash.com/@itslarryg" className="style-link">
+          <a
+            href="https://unsplash.com/@itslarryg"
+            className="style-link"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             Larry George II
           </a>{' '}
           on{' '}
           <a
             href="https://unsplash.com/photos/person-in-grey-crew-neck-shirt-rZUUJ-WyAM0"
             className="style-link"
+            target="_blank"
+            rel="noopener noreferrer"
           >
             Unsplash
           </a>
@@ -62,6 +69,8 @@ const Styles = () => {
             <a
               href="https://unsplash.com/@samanthasophia"
               className="style-link"
+              target="_blank"
+              rel="noopener noreferrer"
             >
               Samantha Sophia
             </a>{' '}
@@ -69,6 +78,8 @@ const Styles = () => {
             <a
               href="https://unsplash.com/photos/woman-taking-selfie-inside-N-MYXygSKYg"
               className="style-link"
+              target="_blank"
+              rel="noopener noreferrer"
             >
               Unsplash
             </a>
@@ -112,13 +123,20 @@ const Styles = () => {
           ></img>
           <figcaption>
             Photo by{' '}
-            <a href="https://unsplash.com/@jabarib" className="style-link">
+            <a
+              href="https://unsplash.com/@jabarib"
+              className="style-link"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               Jabari Timothy
             </a>{' '}
             on{' '}
             <a
               href="https://unsplash.com/photos/woman-in-black-shirt-wearing-white-cowboy-hat-and-sunglasses-UyEgIEfLen8"
               className="style-link"
+              target="_blank"
+              rel="noopener noreferrer"
             >
               Unsplash
             </a>

--- a/src/Components/Styles/Styles.js
+++ b/src/Components/Styles/Styles.js
@@ -79,8 +79,13 @@ const Styles = () => {
           different sizes. Since sisterlocks are a patented technique, they can
           be expensive to install and maintain, but they offer a lot of
           versatility in terms of hair styling options and the same benefits as
-          interlocking above. You can also find a sisterlocks consultant via the
-          <a href="https://www.sisterlocks.com/certified-consultant-registry.html">
+          interlocking above. You can also find a sisterlocks consultant via the{' '}
+          <a
+            href="https://www.sisterlocks.com/certified-consultant-registry.html"
+            className="style-link"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             official certified consultant registry.
           </a>
         </p>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Overview
This updates the color of one of the links on the styles page from white to red. 

<!--- Describe your changes in detail -->

## Background
All of the links on this page should be red but the default link color for the repo is white. This isn't ideal since this results in white text on a white background. 
While making this update I noticed that not all external links open in a new tab, so added `target="_blank"` to all of them. 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing
You can git clone the repo, git switch to this branch, and run `npm start` to verify that the UI has been updated and the link is now red. 

<!--- Please describe in detail how to test these changes. -->

## Screenshot(s):
Before:
<img width="733" alt="Screen Shot 2023-11-09 at 4 41 43 PM" src="https://github.com/garnetred/loc-collective/assets/59572865/b2d2621d-ba3d-4869-ac4e-fd2992318ba9">

After:
<img width="743" alt="Screen Shot 2023-11-09 at 4 42 36 PM" src="https://github.com/garnetred/loc-collective/assets/59572865/0047efb7-c3ac-409a-835e-716e3460b705">

<!-- Please include any screenshots if applicable. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have self-reviewed my code and added comments where relevant.
- [ ] I have updated any relevant documentation.