### PR TITLE
Feat/make stylist page responsive

### DIFF
--- a/src/Components/SearchResults/SearchResults.css
+++ b/src/Components/SearchResults/SearchResults.css
@@ -4,7 +4,7 @@
   height: 25%;
   margin: 2% 0;
   border-radius: 5px;
-  width: 85%;
+  width: 75%;
 }
 
 .search-result-header {
@@ -69,10 +69,22 @@ h3 {
   }
 
   .specific-search-result {
+    width: 95%;
+  }
+}
+@media only screen and (min-width: 601px) and (max-width: 767px) {
+  /* .company-image {
+    width: 20%;
+  } */
+  .star-rating {
+    margin: 2% auto;
+  }
+
+  .specific-search-result {
     width: 100%;
   }
 }
-@media only screen and (min-width: 601px) {
+@media only screen and (min-width: 768px) and (max-width: 1199px) {
   /* .company-image {
     width: 20%;
   } */
@@ -81,19 +93,7 @@ h3 {
   }
 
   .specific-search-result {
-    width: min-content;
-  }
-}
-@media only screen and (min-width: 768px) {
-  /* .company-image {
-    width: 20%;
-  } */
-  .star-rating {
-    margin: 2% auto;
-  }
-
-  .specific-search-result {
-    width: min-content;
+    width: 100%;
   }
 }
 
@@ -105,7 +105,7 @@ h3 {
     margin: 2% auto;
   }
 
-  .specific-search-result {
+  /* .specific-search-result {
     width: min-content;
-  }
+  } */
 }

--- a/src/Components/SearchResults/SearchResults.css
+++ b/src/Components/SearchResults/SearchResults.css
@@ -4,6 +4,7 @@
   height: 25%;
   margin: 2% 0;
   border-radius: 5px;
+  width: 85%;
 }
 
 .search-result-header {
@@ -66,6 +67,10 @@ h3 {
   .search-results-content {
     flex-direction: column;
   }
+
+  .specific-search-result {
+    width: 100%;
+  }
 }
 @media only screen and (min-width: 601px) {
   /* .company-image {
@@ -73,6 +78,10 @@ h3 {
   } */
   .star-rating {
     margin: 2% auto;
+  }
+
+  .specific-search-result {
+    width: min-content;
   }
 }
 @media only screen and (min-width: 768px) {
@@ -82,6 +91,10 @@ h3 {
   .star-rating {
     margin: 2% auto;
   }
+
+  .specific-search-result {
+    width: min-content;
+  }
 }
 
 @media only screen and (min-width: 1200px) {
@@ -90,5 +103,9 @@ h3 {
   } */
   .star-rating {
     margin: 2% auto;
+  }
+
+  .specific-search-result {
+    width: min-content;
   }
 }

--- a/src/Components/SearchResultsContainer/SearchResultsContainer.css
+++ b/src/Components/SearchResultsContainer/SearchResultsContainer.css
@@ -44,7 +44,7 @@
     margin: 0 auto;
   }
 }
-@media only screen and (min-width: 601px) {
+@media only screen and (min-width: 601px) and (max-width: 767px) {
   .search-results-container {
     width: 100%;
   }
@@ -58,7 +58,7 @@
     margin: 0 auto;
   }
 }
-@media only screen and (min-width: 768px) {
+@media only screen and (min-width: 768px) and (max-width: 1199px) {
   .search-results-container {
     width: 100%;
   }

--- a/src/Components/SearchResultsContainer/SearchResultsContainer.css
+++ b/src/Components/SearchResultsContainer/SearchResultsContainer.css
@@ -68,8 +68,11 @@
   }
 
   .all-search-results {
-    width: 90%;
+    width: 55%;
     margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
   }
 }
 @media only screen and (min-width: 1200px) {

--- a/src/Components/StylistPage/StylistPage.css
+++ b/src/Components/StylistPage/StylistPage.css
@@ -89,3 +89,102 @@ h3 {
 .review-text {
   font-style: italic;
 }
+
+@media only screen and (max-width: 600px) {
+  .stylist-content {
+    flex-direction: column;
+  }
+
+  .stylist-name-and-rating {
+    flex-direction: column;
+  }
+
+  .stylist-header {
+    align-items: normal;
+    margin: 1% 0;
+  }
+
+  .stylist-container {
+    height: fit-content;
+    width: 90%;
+  }
+
+  .stylist-company-image {
+    width: 70%;
+  }
+
+  .stylist-info-container > article {
+    margin-left: 0;
+  }
+
+  .reviews {
+    margin-left: 0;
+  }
+}
+
+@media only screen and (min-width: 601px) and (max-width: 767px) {
+  .stylist-content {
+    flex-direction: column;
+  }
+
+  .stylist-name-and-rating {
+    flex-direction: column;
+  }
+
+  .stylist-header {
+    align-items: normal;
+    margin: 1% 0;
+  }
+
+  .stylist-container {
+    height: fit-content;
+    width: 90%;
+  }
+
+  .stylist-company-image {
+    width: 70%;
+  }
+
+  .stylist-info-container > article {
+    margin-left: 0;
+  }
+
+  .reviews {
+    margin-left: 0;
+  }
+}
+
+@media only screen and (min-width: 768px) and (max-width: 1199px) {
+  .star-rating {
+    margin: 0;
+  }
+
+  .stylist-content {
+    flex-direction: column;
+  }
+
+  .stylist-header {
+    align-items: normal;
+    margin: 1% 0;
+  }
+
+  .stylist-container {
+    height: fit-content;
+    width: 90%;
+  }
+
+  .stylist-company-image {
+    width: 50%;
+  }
+
+  .stylist-info-container > article {
+    margin-left: 0;
+  }
+
+  .reviews {
+    margin-left: 0;
+  }
+}
+
+@media only screen and (min-width: 1200px) {
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Overview
These changes make the stylist page mobile responsive. 
<!--- Describe your changes in detail -->

## Background
In #97 , I added mobile responsiveness to the home page. To make the stylist page mobile responsive, I mostly used flexbox and changed the flex direction to stack items in columns instead of displaying them side by side in rows. 

I also made minor adjustments to the search results for desktop and tablet sizes. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing
You can test by git cloning the repo with the SSH url, git switching to this branch, and running `npm start` to start the local server. From there, you can open dev tools in your browser and click on the option to view mobile/tablet sizes. You should see on the stylist page after initiating a search and clicking on a particular stylist that the mobile and tablet views are easy to read, images are a decent size, etc. 
<!--- Please describe in detail how to test these changes. -->

## Screenshot(s):
Before:
<img width="298" alt="Screen Shot 2023-11-11 at 8 24 21 AM" src="https://github.com/garnetred/loc-collective/assets/59572865/493718fc-b18c-47c5-8680-b97ec8a14c52">


After: 
<img width="295" alt="Screen Shot 2023-11-11 at 8 20 28 AM" src="https://github.com/garnetred/loc-collective/assets/59572865/aae1e471-eaeb-4f9b-a66f-35adf30ff40f">

<!-- Please include any screenshots if applicable. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have self-reviewed my code and added comments where relevant.
- [ ] I have updated any relevant documentation.